### PR TITLE
Potential fix for code scanning alert no. 3: Incorrect conversion between integer types

### DIFF
--- a/internal/codespaces/portforwarder/port_forwarder.go
+++ b/internal/codespaces/portforwarder/port_forwarder.go
@@ -244,6 +244,11 @@ func (fwd *CodespacesPortForwarder) UpdatePortVisibility(ctx context.Context, re
 		return nil
 	}
 
+	// Validate the remotePort value before converting to uint16
+	if remotePort < 0 || remotePort > 65535 {
+		return fmt.Errorf("invalid port number: %d. Port must be between 0 and 65535", remotePort)
+	}
+
 	// Delete the existing tunnel port to update
 	err = fwd.connection.TunnelManager.DeleteTunnelPort(ctx, fwd.connection.Tunnel, uint16(remotePort), fwd.connection.Options)
 	if err != nil {


### PR DESCRIPTION
Potential fix for [https://github.com/akabarki76/cli/security/code-scanning/3](https://github.com/akabarki76/cli/security/code-scanning/3)

To fix the issue, we need to ensure that the `remotePort` value is within the valid range for `uint16` before performing the conversion. This can be achieved by adding explicit bounds checks for `remotePort` (i.e., ensuring it is between 0 and 65535 inclusive). If the value is out of bounds, the code should handle the error gracefully, such as by returning an error or using a default value.

The changes will be made in the `UpdatePortVisibility` method in `internal/codespaces/portforwarder/port_forwarder.go`. Specifically, we will add bounds checks for `remotePort` before converting it to `uint16`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
