### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,5 +1,8 @@
 name: Discussion Triage
 run-name: ${{ github.event_name == 'issues' && github.event.issue.title || github.event.pull_request.title }}
+permissions:
+  contents: read
+  issues: write
 on:
   issues:
     types:


### PR DESCRIPTION
Potential fix for [https://github.com/akabarki76/cli/security/code-scanning/2](https://github.com/akabarki76/cli/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the root of the workflow. This block will define the minimal permissions required for the workflow to function. Based on the workflow's operations, it appears to require `contents: read` to access repository contents and `issues: write` to create issues. No other permissions are necessary.

The `permissions` block will be added at the top level of the workflow, ensuring it applies to all jobs unless overridden by a job-specific `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
