### PR TITLE
Potential fix for code scanning alert no. 11: Clear-text logging of sensitive information

### DIFF
--- a/third-party/github.com/letsencrypt/boulder/akamai/cache-client.go
+++ b/third-party/github.com/letsencrypt/boulder/akamai/cache-client.go
@@ -331,8 +331,9 @@ func CheckSignature(secret string, url string, r *http.Request, body []byte) err
 	h.Write(input)
 	expectedSignature := base64.StdEncoding.EncodeToString(h.Sum(nil))
 	if signature != expectedSignature {
-		return fmt.Errorf("expected signature %q, got %q in %q",
-			signature, authorization, expectedSignature)
+		sanitizedAuth := sanitizeAuthorizationHeader(authorization)
+		return fmt.Errorf("expected signature %q, got sanitized authorization header %q in %q",
+			signature, sanitizedAuth, expectedSignature)
 	}
 	return nil
 }
@@ -342,6 +343,14 @@ func reverseBytes(b []byte) []byte {
 		b[i], b[j] = b[j], b[i]
 	}
 	return b
+}
+
+// sanitizeAuthorizationHeader obfuscates sensitive parts of the Authorization header.
+func sanitizeAuthorizationHeader(authHeader string) string {
+	if len(authHeader) > 10 {
+		return authHeader[:5] + "..." + authHeader[len(authHeader)-5:]
+	}
+	return "REDACTED"
 }
 
 // makeOCSPCacheURLs constructs the 3 URLs associated with each cached OCSP

--- a/third-party/github.com/letsencrypt/boulder/test/akamai-test-srv/main.go
+++ b/third-party/github.com/letsencrypt/boulder/test/akamai-test-srv/main.go
@@ -61,7 +61,7 @@ func main() {
 		}
 		if err = akamai.CheckSignature(*secret, "http://"+*listenAddr, r, body); err != nil {
 			w.WriteHeader(http.StatusUnauthorized)
-			fmt.Println("Bad signature:", err)
+			fmt.Println("Bad signature error:", err)
 			return
 		}
 		if err = json.Unmarshal(body, &purgeRequest); err != nil {


### PR DESCRIPTION
Potential fix for [https://github.com/akabarki76/cli/security/code-scanning/11](https://github.com/akabarki76/cli/security/code-scanning/11)

To address the issue, we will sanitize the error message in `akamai.CheckSignature` to avoid logging sensitive information such as the `Authorization` header. Instead, we will log a generic error message or obfuscate the sensitive parts of the header. This ensures that sensitive data is not exposed in plaintext logs while still providing useful debugging information.

The changes will involve:
1. Modifying the `akamai.CheckSignature` function in `third-party/github.com/letsencrypt/boulder/akamai/cache-client.go` to sanitize the `Authorization` header before including it in the error message.
2. Updating the logging call in `third-party/github.com/letsencrypt/boulder/test/akamai-test-srv/main.go` to reflect the sanitized error message.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
