### PR TITLE
Potential fix for code scanning alert no. 23: Log entries created from user input

### DIFF
--- a/third-party/github.com/letsencrypt/boulder/web/context.go
+++ b/third-party/github.com/letsencrypt/boulder/web/context.go
@@ -141,6 +141,10 @@ func (th *TopHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		realIP = "0.0.0.0"
 	}
 
+	// Sanitize the realIP value to remove newline and carriage return characters.
+	realIP = strings.ReplaceAll(realIP, "\n", "")
+	realIP = strings.ReplaceAll(realIP, "\r", "")
+
 	userAgent := r.Header.Get("User-Agent")
 
 	logEvent := &RequestEvent{


### PR DESCRIPTION
Potential fix for [https://github.com/akabarki76/cli/security/code-scanning/23](https://github.com/akabarki76/cli/security/code-scanning/23)

To fix the issue, we need to sanitize the `realIP` value before logging it. Specifically, we should remove any newline (`\n`) or carriage return (`\r`) characters from the `realIP` string. This can be achieved using the `strings.ReplaceAll` function. The sanitization should be applied immediately after the `realIP` value is validated and before it is assigned to the `logEvent.RealIP` field.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
