### PR TITLE
Potential fix for code scanning alert no. 3: Incorrect conversion between integer types

### DIFF
--- a/internal/codespaces/portforwarder/port_forwarder.go
+++ b/internal/codespaces/portforwarder/port_forwarder.go
@@ -263,6 +263,11 @@ func (fwd *CodespacesPortForwarder) UpdatePortVisibility(ctx context.Context, re
 		return nil
 	}
 
+	// Validate the port number before converting to uint16
+	if remotePort < 0 || remotePort > 65535 {
+		return fmt.Errorf("invalid port number: %d. Port must be between 0 and 65535", remotePort)
+	}
+
 	// Delete the existing tunnel port to update
 	err = fwd.connection.TunnelManager.DeleteTunnelPort(ctx, fwd.connection.Tunnel, uint16(remotePort), fwd.connection.Options)
 	if err != nil {


### PR DESCRIPTION
Potential fix for [https://github.com/akabarki76/cli/security/code-scanning/3](https://github.com/akabarki76/cli/security/code-scanning/3)

To fix the issue, we need to ensure that the `remotePort` value is within the valid range for `uint16` (0 to 65535) before performing the conversion. This can be achieved by adding an explicit bounds check. If the value is out of range, the function should return an error or handle it gracefully.

The best approach is to validate `remotePort` in the `UpdatePortVisibility` function before converting it to `uint16`. This ensures that the conversion is safe and prevents potential issues downstream.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
